### PR TITLE
Fix parsing of comments before package definition (#34)

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -327,6 +327,9 @@ spc = Drop(Star(Space()))
     WS = p" " | p"\t" | NL
     LINE_COMMENT = p"//[^\r\n]*" + NL
     ML_COMMENT = p"/[*]([^*]|([*][^/]))*[*]/"
+    
+    # Pattern to match initial comments and whitespace at the beginning of file
+    initial_spc_and_comments = Drop(Star(WS | LINE_COMMENT | ML_COMMENT))
 
     #lexical units, not keywords
     NONDIGIT = p"_|[a-z]|[A-Z]"
@@ -585,7 +588,7 @@ spc = Drop(Star(Space()))
                          (spc + E"=" + spc + expression)[0:1]) |>
                         BaseModelicaSimpleEquation) + comment > BaseModelicaAnyEquation
 
-    base_modelica = (spc + E"package" + spc + IDENT + spc +
+    base_modelica = (initial_spc_and_comments + E"package" + spc + IDENT + spc +
                      Star((decoration[0:1] + spc + class_definition + spc + E";") |
                           (decoration[0:1] + global_constant + E";")) +
                      spc + decoration[0:1] + spc +

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,13 @@ if GROUP == "All" || GROUP == "Core"
             newton_system = BM.baseModelica_to_ModelingToolkit(newton_cooling)
             @test newton_system isa ODESystem
             @test parse_basemodelica("testfiles/NewtonCoolingBase.mo") isa ODESystem
+            
+            # Test parsing with comments before package (issue #34)
+            comment_path = joinpath(
+                dirname(dirname(pathof(BM))), "test", "testfiles", "CommentBeforePackage.mo")
+            comment_package = BM.parse_file(comment_path)
+            @test comment_package isa BM.BaseModelicaPackage
+            @test comment_package.name == "Comment"
         end
     end
 end

--- a/test/testfiles/CommentBeforePackage.mo
+++ b/test/testfiles/CommentBeforePackage.mo
@@ -1,0 +1,8 @@
+//! base 0.1.0
+package 'Comment'
+  model 'Comment'
+    Real 'x';
+  equation
+    der('x') = 'x';
+  end 'Comment';
+end 'Comment';


### PR DESCRIPTION
## Summary

- Add `initial_spc_and_comments` pattern to handle comments and whitespace at the beginning of files
- Modify `base_modelica` parser to use the new pattern instead of just `spc`
- Add test case for files with comments before package definition

## Problem

OpenModelica generates Base Modelica files with comments like `//! base 0.1.0` at the beginning of files, which broke the BaseModelica.jl parser because it expected the first non-whitespace token to be `package`.

## Solution

The parser now accepts comments and whitespace before the `package` keyword by:
1. Creating an `initial_spc_and_comments` pattern that matches whitespace, newlines, line comments, and multi-line comments
2. Modifying the `base_modelica` parser definition to start with this new pattern instead of just `spc`

## Test plan

- [x] Added test file `test/testfiles/CommentBeforePackage.mo` with the example from the issue
- [x] Added test case in `test/runtests.jl` to verify the fix works
- [x] Parsing files with comments before package definition now works correctly

## Fixes

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)