### PR TITLE
Add support for experiment annotations within equation blocks (#38)

### DIFF
--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -49,6 +49,12 @@ function eval_AST(eq::BaseModelicaAnyEquation)
     return equation
 end
 
+function eval_AST(annotation::BaseModelicaAnnotation)
+    # Annotations are metadata and don't produce equations
+    # For now, return nothing (they are parsed but ignored during evaluation)
+    return nothing
+end
+
 function eval_AST(eq::BaseModelicaSimpleEquation)
     lhs = eval_AST(eq.lhs)
     rhs = eval_AST(eq.rhs)
@@ -102,7 +108,7 @@ function eval_AST(model::BaseModelicaModel)
         end
     end
 
-    eqs = [eval_AST(eq) for eq in equations]
+    eqs = filter(x -> x !== nothing, [eval_AST(eq) for eq in equations])
 
     #vars_and_pars = merge(Dict(vars .=> vars), Dict(pars .=> pars))
     #println(vars_and_pars)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,11 @@ if GROUP == "All" || GROUP == "Core"
             unary_minus_test = only(PC.parse_one("-5", BM.arithmetic_expression))
             @test unary_minus_test isa BM.BaseModelicaUnaryMinus
             @test BM.eval_AST(unary_minus_test) == -5.0
+            
+            # Test annotation parsing (issue #38)
+            annotation_test = only(PC.parse_one("annotation(experiment(StartTime = 0, StopTime = 2.0))", BM.annotation_comment))
+            @test annotation_test isa BM.BaseModelicaAnnotation
+            @test BM.eval_AST(annotation_test) === nothing
 
             newton_path = joinpath(
                 dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.mo")
@@ -41,6 +46,15 @@ if GROUP == "All" || GROUP == "Core"
             negative_system = BM.baseModelica_to_ModelingToolkit(negative_package)
             @test negative_system isa ODESystem
             @test parse_basemodelica("testfiles/NegativeVariable.mo") isa ODESystem
+            
+            # Test experiment annotation parsing (issue #38)
+            experiment_path = joinpath(
+                dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.mo")
+            experiment_package = BM.parse_file(experiment_path)
+            @test experiment_package isa BM.BaseModelicaPackage
+            experiment_system = BM.baseModelica_to_ModelingToolkit(experiment_package)
+            @test experiment_system isa ODESystem
+            @test parse_basemodelica("testfiles/Experiment.mo") isa ODESystem
         end
     end
 end

--- a/test/testfiles/Experiment.mo
+++ b/test/testfiles/Experiment.mo
@@ -1,0 +1,8 @@
+package 'Experiment'
+  model 'Experiment'
+    Real 'x';
+  equation
+    der('x') = 'x';
+    annotation(experiment(StartTime = 0, StopTime = 2.0, Tolerance = 1e-06, Interval = 0.004));
+  end 'Experiment';
+end 'Experiment';


### PR DESCRIPTION
## Summary

This PR adds support for experiment annotations and other annotations that appear within equation blocks in BaseModelica models.

## Problem

The parser could not handle annotations like `annotation(experiment(...))` when they appeared within equation sections of models. The issue reported:

```modelica
equation
  der('x') = 'x';
  annotation(experiment(StartTime = 0, StopTime = 2.0, Tolerance = 1e-06, Interval = 0.004));
```

This failed with `ParserCombinator.ParserException("cannot parse")` because the equation section parser only expected pure equations, not annotations.

## Solution

1. **Added BaseModelicaAnnotation AST node**: New node type to represent annotations within models
2. **Enhanced equation section parsing**: Modified composition parser to allow both equations and annotations in equation blocks
3. **Updated BaseModelicaComposition**: Extended to handle BaseModelicaAnnotation alongside equations
4. **Added annotation evaluation**: Annotations are treated as metadata that returns `nothing` during evaluation
5. **Filtered evaluation results**: Filter out `nothing` values when building equation lists

## Changes

- **src/parser.jl**:
  - Added `BaseModelicaAnnotation(annotation_content)` AST node
  - Modified equation section parsing: `Star(spc + (equation | annotation_comment) + E";" + spc)`
  - Updated `annotation_comment` to produce `BaseModelicaAnnotation`
  - Extended `BaseModelicaComposition` function to handle annotations
  
- **src/evaluator.jl**:
  - Added `eval_AST(annotation::BaseModelicaAnnotation)` returning `nothing`
  - Updated equation filtering to exclude `nothing` values from evaluation

- **test/runtests.jl**:
  - Added unit test for annotation parsing
  - Added integration test for full model with experiment annotation

- **test/testfiles/Experiment.mo**: Test file with experiment annotation from issue

## Test plan

- [x] Unit test verifies `annotation(experiment(...))` parses as `BaseModelicaAnnotation`
- [x] Unit test verifies annotation evaluation returns `nothing` 
- [x] Integration test parses full model with experiment annotation
- [x] Integration test successfully creates ODESystem from annotated model
- [x] Existing tests continue to pass

Annotations are now parsed and stored but treated as metadata during evaluation, which is the correct behavior for experiment annotations.

## Fixes

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)