### PR TITLE
Add support for parsing annotations

### DIFF
--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -49,6 +49,12 @@ function eval_AST(eq::BaseModelicaAnyEquation)
     return equation
 end
 
+function eval_AST(annotation::BaseModelicaAnnotation)
+    # Annotations are metadata and don't produce equations
+    # For now, return nothing (they are parsed but ignored during evaluation)
+    return nothing
+end
+
 function eval_AST(eq::BaseModelicaSimpleEquation)
     lhs = eval_AST(eq.lhs)
     rhs = eval_AST(eq.rhs)
@@ -102,7 +108,7 @@ function eval_AST(model::BaseModelicaModel)
         end
     end
 
-    eqs = [eval_AST(eq) for eq in equations]
+    eqs = filter(x -> x !== nothing, [eval_AST(eq) for eq in equations])
 
     #vars_and_pars = merge(Dict(vars .=> vars), Dict(pars .=> pars))
     #println(vars_and_pars)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -303,9 +303,6 @@ function BaseModelicaComposition(input_list)
         elseif input isa BaseModelicaAnyEquation
             push!(equations, input)
         elseif input isa BaseModelicaAnnotation
-            # For now, treat annotations as part of equations 
-            # (they appear in equation sections)
-            push!(equations, input)
         end
     end
     BaseModelicaComposition(components, equations, initial_equations)
@@ -442,7 +439,7 @@ spc = Drop(Star(Space()))
     subscript = (E":" > BMColon) | expression
     array_subscripts.matcher = E"[" + subscript + Star(E"," + subscript) + E"]" |>
                                BaseModelicaArraySubscripts
-    annotation_comment = E"annotation" + class_modification > BaseModelicaAnnotation
+    annotation_comment = E"annotation" + class_modification |> BaseModelicaAnnotation
     comment.matcher = (string_comment + annotation_comment[0:1]) |> (x -> length(x) == 1 ? x[1] : BaseModelicaString(join([string(elem) for elem in x], " ")))
 
     enumeration_literal = IDENT + comment

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,11 @@ if GROUP == "All" || GROUP == "Core"
             unary_minus_test = only(PC.parse_one("-5", BM.arithmetic_expression))
             @test unary_minus_test isa BM.BaseModelicaUnaryMinus
             @test BM.eval_AST(unary_minus_test) == -5.0
+            
+            # Test annotation parsing (issue #38)
+            annotation_test = only(PC.parse_one("annotation(experiment(StartTime = 0, StopTime = 2.0))", BM.annotation_comment))
+            @test annotation_test isa BM.BaseModelicaAnnotation
+            @test BM.eval_AST(annotation_test) === nothing
 
             newton_path = joinpath(
                 dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.mo")
@@ -41,6 +46,15 @@ if GROUP == "All" || GROUP == "Core"
             negative_system = BM.baseModelica_to_ModelingToolkit(negative_package)
             @test negative_system isa ODESystem
             @test parse_basemodelica("testfiles/NegativeVariable.mo") isa ODESystem
+            
+            # Test experiment annotation parsing (issue #38)
+            experiment_path = joinpath(
+                dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.mo")
+            experiment_package = BM.parse_file(experiment_path)
+            @test experiment_package isa BM.BaseModelicaPackage
+            experiment_system = BM.baseModelica_to_ModelingToolkit(experiment_package)
+            @test experiment_system isa ODESystem
+            @test parse_basemodelica("testfiles/Experiment.mo") isa ODESystem
         end
     end
 end

--- a/test/testfiles/Experiment.mo
+++ b/test/testfiles/Experiment.mo
@@ -1,0 +1,8 @@
+package 'Experiment'
+  model 'Experiment'
+    Real 'x';
+  equation
+    der('x') = 'x';
+    annotation(experiment(StartTime = 0, StopTime = 2.0, Tolerance = 1e-06, Interval = 0.004));
+  end 'Experiment';
+end 'Experiment';


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
This should at least let models with annotations parse, they just won't do anything. 
https://github.com/SciML/BaseModelica.jl/issues/38
