### PR TITLE
Fix: Replace ODESystem with System in tests for ModelingToolkit v10 compat

### DIFF
--- a/test/test_antlr_parser.jl
+++ b/test/test_antlr_parser.jl
@@ -41,7 +41,7 @@ BM = BaseModelica
         param_modifiers_package = BM.parse_file_antlr(param_modifiers_path)
         @test param_modifiers_package isa BM.BaseModelicaPackage
         param_modifiers_system = BM.baseModelica_to_ModelingToolkit(param_modifiers_package)
-        @test param_modifiers_system isa ODESystem
+        @test param_modifiers_system isa System
         @test parse_basemodelica(param_modifiers_path, parser=:antlr) isa System
     end
 

--- a/test/test_julia_parser.jl
+++ b/test/test_julia_parser.jl
@@ -63,7 +63,7 @@ PC = BM.ParserCombinator
         param_modifiers_package = BM.parse_file_julia(param_modifiers_path)
         @test param_modifiers_package isa BM.BaseModelicaPackage
         param_modifiers_system = BM.baseModelica_to_ModelingToolkit(param_modifiers_package)
-        @test param_modifiers_system isa ODESystem
+        @test param_modifiers_system isa System
         @test parse_basemodelica(param_modifiers_path, parser=:julia) isa System
     end
 


### PR DESCRIPTION
## Summary

Fix the Downgrade CI test failure by replacing `ODESystem` with `System` in tests.

## Problem

The Downgrade CI workflow runs tests with minimum compatible dependency versions (ModelingToolkit v10). In these older versions, `ODESystem` is not exported/available, causing test failures:

```
UndefVarError: `ODESystem` not defined
```

at `test/test_julia_parser.jl:66` and `test/test_antlr_parser.jl:44`.

## Changes

- `test/test_julia_parser.jl:66`: Changed `ODESystem` to `System`
- `test/test_antlr_parser.jl:44`: Changed `ODESystem` to `System`

## Test plan

- [x] All tests pass locally with `Pkg.test()`
- [ ] Downgrade CI passes with this fix
- [ ] Regular Tests CI passes

## Notes

The Format Check CI is also failing due to formatting issues in the codebase, but addressing formatting is outside the scope of this fix (and was explicitly excluded from the CI health check scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)