### PR TITLE
Add if-expression and if-equation support (fixes #39, #41)

### DIFF
--- a/test/test_antlr_parser.jl
+++ b/test/test_antlr_parser.jl
@@ -7,7 +7,8 @@ BM = BaseModelica
 @testset "ANTLR Parser Tests" begin
     @testset "Newton Cooling" begin
         newton_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo"
+        )
         newton_cooling = BM.parse_file_antlr(newton_path)
         @test newton_cooling isa BM.BaseModelicaPackage
         newton_system = BM.baseModelica_to_ModelingToolkit(newton_cooling)
@@ -17,7 +18,8 @@ BM = BaseModelica
 
     @testset "Negative Variables" begin
         negative_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "NegativeVariable.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NegativeVariable.bmo"
+        )
         negative_package = BM.parse_file_antlr(negative_path)
         @test negative_package isa BM.BaseModelicaPackage
         negative_system = BM.baseModelica_to_ModelingToolkit(negative_package)
@@ -27,7 +29,8 @@ BM = BaseModelica
 
     @testset "Experiment Annotation" begin
         experiment_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo"
+        )
         experiment_package = BM.parse_file_antlr(experiment_path)
         @test experiment_package isa BM.BaseModelicaPackage
         experiment_system = BM.baseModelica_to_ModelingToolkit(experiment_package)
@@ -37,7 +40,8 @@ BM = BaseModelica
 
     @testset "Parameter with Modifiers" begin
         param_modifiers_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "ParameterWithModifiers.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "ParameterWithModifiers.bmo"
+        )
         param_modifiers_package = BM.parse_file_antlr(param_modifiers_path)
         @test param_modifiers_package isa BM.BaseModelicaPackage
         param_modifiers_system = BM.baseModelica_to_ModelingToolkit(param_modifiers_package)
@@ -47,7 +51,8 @@ BM = BaseModelica
 
     @testset "If Equations" begin
         if_equations_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "IfEquation.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "IfEquation.bmo"
+        )
         if_equations_package = BM.parse_file_antlr(if_equations_path)
         @test if_equations_package isa BM.BaseModelicaPackage
         if_equations_system = BM.baseModelica_to_ModelingToolkit(if_equations_package)
@@ -55,10 +60,66 @@ BM = BaseModelica
         @test parse_basemodelica(if_equations_path, parser = :antlr) isa System
     end
 
+    @testset "Inline If Expression (issue #39)" begin
+        inline_if_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "InlineIf.bmo"
+        )
+        inline_if_package = BM.parse_file_antlr(inline_if_path)
+        @test inline_if_package isa BM.BaseModelicaPackage
+        inline_if_system = BM.baseModelica_to_ModelingToolkit(inline_if_package)
+        @test inline_if_system isa System
+        @test parse_basemodelica(inline_if_path, parser = :antlr) isa System
+    end
+
+    @testset "Nested Inline If Expression (issue #39)" begin
+        nested_if_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "InlineIfNested.bmo"
+        )
+        nested_if_package = BM.parse_file_antlr(nested_if_path)
+        @test nested_if_package isa BM.BaseModelicaPackage
+        nested_if_system = BM.baseModelica_to_ModelingToolkit(nested_if_package)
+        @test nested_if_system isa System
+        @test parse_basemodelica(nested_if_path, parser = :antlr) isa System
+    end
+
+    @testset "Inline If-ElseIf Expression (issue #39)" begin
+        elseif_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "InlineIfElseIf.bmo"
+        )
+        elseif_package = BM.parse_file_antlr(elseif_path)
+        @test elseif_package isa BM.BaseModelicaPackage
+        elseif_system = BM.baseModelica_to_ModelingToolkit(elseif_package)
+        @test elseif_system isa System
+        @test parse_basemodelica(elseif_path, parser = :antlr) isa System
+    end
+
+    @testset "If-ElseIf-Else Equation (issue #41)" begin
+        ifeq_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "IfElseIfEquation.bmo"
+        )
+        ifeq_package = BM.parse_file_antlr(ifeq_path)
+        @test ifeq_package isa BM.BaseModelicaPackage
+        ifeq_system = BM.baseModelica_to_ModelingToolkit(ifeq_package)
+        @test ifeq_system isa System
+        @test parse_basemodelica(ifeq_path, parser = :antlr) isa System
+    end
+
+    @testset "No Else If Equation (issue #41)" begin
+        noelse_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NoElse.bmo"
+        )
+        noelse_package = BM.parse_file_antlr(noelse_path)
+        @test noelse_package isa BM.BaseModelicaPackage
+        noelse_system = BM.baseModelica_to_ModelingToolkit(noelse_package)
+        @test noelse_system isa System
+        @test parse_basemodelica(noelse_path, parser = :antlr) isa System
+    end
+
     @testset "Cauer Low Pass Filters" begin
         # Test CauerLowPassAnalog
         cauer_analog_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalog.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalog.bmo"
+        )
         cauer_analog_package = BM.parse_file_antlr(cauer_analog_path)
         @test cauer_analog_package isa BM.BaseModelicaPackage
         cauer_analog_system = BM.baseModelica_to_ModelingToolkit(cauer_analog_package)
@@ -68,14 +129,15 @@ BM = BaseModelica
         # Test that initial conditions (fixed=true) are set correctly
         # MTK v11 replaced defaults with initial_conditions and bindings
         @test !isempty(ModelingToolkit.initial_conditions(cauer_analog_system)) ||
-              !isempty(ModelingToolkit.bindings(cauer_analog_system))
+            !isempty(ModelingToolkit.bindings(cauer_analog_system))
 
         # Test that guess values (fixed=false or no fixed) are set correctly
         @test !isempty(ModelingToolkit.guesses(cauer_analog_system))
 
         # Test CauerLowPassAnalogSine
         cauer_sine_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSine.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSine.bmo"
+        )
         cauer_sine_package = BM.parse_file_antlr(cauer_sine_path)
         @test cauer_sine_package isa BM.BaseModelicaPackage
         cauer_sine_system = BM.baseModelica_to_ModelingToolkit(cauer_sine_package)
@@ -84,7 +146,8 @@ BM = BaseModelica
 
         # Test CauerLowPassAnalogSineNoAssert
         cauer_sine_noassert_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSineNoAssert.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSineNoAssert.bmo"
+        )
         cauer_sine_noassert_package = BM.parse_file_antlr(cauer_sine_noassert_path)
         @test cauer_sine_noassert_package isa BM.BaseModelicaPackage
         cauer_sine_noassert_system = BM.baseModelica_to_ModelingToolkit(cauer_sine_noassert_package)
@@ -95,7 +158,8 @@ BM = BaseModelica
     @testset "Chua Circuits" begin
         # Test ChuaCircuit
         chua_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "ChuaCircuit.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "ChuaCircuit.bmo"
+        )
         chua_package = BM.parse_file_antlr(chua_path)
         @test chua_package isa BM.BaseModelicaPackage
         chua_system = BM.baseModelica_to_ModelingToolkit(chua_package)
@@ -104,7 +168,8 @@ BM = BaseModelica
 
         # Test ChuaCircuitNoAssert
         chua_noassert_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "ChuaCircuitNoAssert.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "ChuaCircuitNoAssert.bmo"
+        )
         chua_noassert_package = BM.parse_file_antlr(chua_noassert_path)
         @test chua_noassert_package isa BM.BaseModelicaPackage
         chua_noassert_system = BM.baseModelica_to_ModelingToolkit(chua_noassert_package)
@@ -115,7 +180,8 @@ BM = BaseModelica
     @testset "Math Functions" begin
         # Test model with cos, tanh, atan2
         math_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "MathFunctions.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "MathFunctions.bmo"
+        )
         math_package = BM.parse_file_antlr(math_path)
         @test math_package isa BM.BaseModelicaPackage
         math_system = BM.baseModelica_to_ModelingToolkit(math_package)
@@ -126,7 +192,8 @@ BM = BaseModelica
     @testset "Math Functions Extended" begin
         # Test model with exp, sqrt, max, noEvent, sign, log, abs
         math_ext_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "MathFunctionsExtended.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "MathFunctionsExtended.bmo"
+        )
         math_ext_package = BM.parse_file_antlr(math_ext_path)
         @test math_ext_package isa BM.BaseModelicaPackage
         math_ext_system = BM.baseModelica_to_ModelingToolkit(math_ext_package)
@@ -142,8 +209,10 @@ BM = BaseModelica
         @test haskey(fmap, :der)
 
         # Elementary math (Spec 3.7.3)
-        for f in [:sin, :cos, :tan, :asin, :acos, :atan, :atan2,
-                  :sinh, :cosh, :tanh, :exp, :log, :log10]
+        for f in [
+                :sin, :cos, :tan, :asin, :acos, :atan, :atan2,
+                :sinh, :cosh, :tanh, :exp, :log, :log10,
+            ]
             @test haskey(fmap, f)
         end
 
@@ -175,7 +244,8 @@ BM = BaseModelica
 
     @testset "Minimal Valid File" begin
         minimal_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "MinimalValid.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "MinimalValid.bmo"
+        )
         minimal_package = BM.parse_file_antlr(minimal_path)
         @test minimal_package isa BM.BaseModelicaPackage
         # don't want to evaluate since there are no equations
@@ -184,7 +254,8 @@ BM = BaseModelica
     @testset "Create ODEProblem with ANTLR Parser" begin
         # Test create_odeproblem with Experiment annotation
         experiment_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo"
+        )
 
         prob = BM.create_odeproblem(experiment_path, parser = :antlr)
         @test prob isa ODEProblem
@@ -194,7 +265,7 @@ BM = BaseModelica
         @test prob.tspan[2] == 2.0  # StopTime
 
         # Check that reltol and saveat were set from annotation
-        @test prob.kwargs[:reltol] == 1e-06  # Tolerance
+        @test prob.kwargs[:reltol] == 1.0e-6  # Tolerance
         @test prob.kwargs[:saveat] == 0.004  # Interval
 
         # Test parse_experiment_annotation directly with ANTLR parser
@@ -207,12 +278,13 @@ BM = BaseModelica
         @test !isnothing(exp_params)
         @test exp_params.StartTime == 0.0
         @test exp_params.StopTime == 2.0
-        @test exp_params.Tolerance == 1e-06
+        @test exp_params.Tolerance == 1.0e-6
         @test exp_params.Interval == 0.004
 
         # Test with model without annotation
         newton_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo"
+        )
         prob_no_annotation = BM.create_odeproblem(newton_path, parser = :antlr)
         @test prob_no_annotation isa ODEProblem
         # Should use default tspan
@@ -225,9 +297,9 @@ BM = BaseModelica
         @test isnothing(newton_annotation)
 
         # Test that user can override annotation values
-        prob_override = BM.create_odeproblem(experiment_path, parser = :antlr, reltol = 1e-8, saveat = 0.01)
+        prob_override = BM.create_odeproblem(experiment_path, parser = :antlr, reltol = 1.0e-8, saveat = 0.01)
         @test prob_override isa ODEProblem
-        @test prob_override.kwargs[:reltol] == 1e-8  # User override
+        @test prob_override.kwargs[:reltol] == 1.0e-8  # User override
         @test prob_override.kwargs[:saveat] == 0.01  # User override
         @test prob_override.tspan[2] == 2.0  # Still from annotation
     end

--- a/test/test_julia_parser.jl
+++ b/test/test_julia_parser.jl
@@ -19,15 +19,19 @@ PC = BM.ParserCombinator
 
     @testset "Annotation Parsing" begin
         # Test annotation parsing (issue #38)
-        annotation_test = only(PC.parse_one(
-            "annotation(experiment(StartTime = 0, StopTime = 2.0))", BM.annotation_comment))
+        annotation_test = only(
+            PC.parse_one(
+                "annotation(experiment(StartTime = 0, StopTime = 2.0))", BM.annotation_comment
+            )
+        )
         @test annotation_test isa BM.BaseModelicaAnnotation
         @test BM.eval_AST(annotation_test) === nothing
     end
 
     @testset "Newton Cooling" begin
         newton_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo"
+        )
         newton_cooling = BM.parse_file_julia(newton_path)
         @test newton_cooling isa BM.BaseModelicaPackage
         newton_system = BM.baseModelica_to_ModelingToolkit(newton_cooling)
@@ -38,7 +42,8 @@ PC = BM.ParserCombinator
     @testset "Negative Variables" begin
         # Test parsing with negative variables (issue #35)
         negative_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "NegativeVariable.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NegativeVariable.bmo"
+        )
         negative_package = BM.parse_file_julia(negative_path)
         @test negative_package isa BM.BaseModelicaPackage
         negative_system = BM.baseModelica_to_ModelingToolkit(negative_package)
@@ -49,7 +54,8 @@ PC = BM.ParserCombinator
     @testset "Experiment Annotation" begin
         # Test experiment annotation parsing (issue #38)
         experiment_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo"
+        )
         experiment_package = BM.parse_file_julia(experiment_path)
         @test experiment_package isa BM.BaseModelicaPackage
         experiment_system = BM.baseModelica_to_ModelingToolkit(experiment_package)
@@ -60,7 +66,8 @@ PC = BM.ParserCombinator
     @testset "Parameter with Modifiers" begin
         # Test parameter with modifiers (issue #49)
         param_modifiers_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "ParameterWithModifiers.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "ParameterWithModifiers.bmo"
+        )
         param_modifiers_package = BM.parse_file_julia(param_modifiers_path)
         @test param_modifiers_package isa BM.BaseModelicaPackage
         param_modifiers_system = BM.baseModelica_to_ModelingToolkit(param_modifiers_package)
@@ -70,7 +77,8 @@ PC = BM.ParserCombinator
 
     @testset "If Equations" begin
         if_equations_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "IfEquation.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "IfEquation.bmo"
+        )
         if_equations_package = BM.parse_file_julia(if_equations_path)
         @test if_equations_package isa BM.BaseModelicaPackage
         if_equations_system = BM.baseModelica_to_ModelingToolkit(if_equations_package)
@@ -78,10 +86,66 @@ PC = BM.ParserCombinator
         @test parse_basemodelica(if_equations_path, parser = :julia) isa System
     end
 
+    @testset "Inline If Expression (issue #39)" begin
+        inline_if_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "InlineIf.bmo"
+        )
+        inline_if_package = BM.parse_file_julia(inline_if_path)
+        @test inline_if_package isa BM.BaseModelicaPackage
+        inline_if_system = BM.baseModelica_to_ModelingToolkit(inline_if_package)
+        @test inline_if_system isa System
+        @test parse_basemodelica(inline_if_path, parser = :julia) isa System
+    end
+
+    @testset "Nested Inline If Expression (issue #39)" begin
+        nested_if_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "InlineIfNested.bmo"
+        )
+        nested_if_package = BM.parse_file_julia(nested_if_path)
+        @test nested_if_package isa BM.BaseModelicaPackage
+        nested_if_system = BM.baseModelica_to_ModelingToolkit(nested_if_package)
+        @test nested_if_system isa System
+        @test parse_basemodelica(nested_if_path, parser = :julia) isa System
+    end
+
+    @testset "Inline If-ElseIf Expression (issue #39)" begin
+        elseif_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "InlineIfElseIf.bmo"
+        )
+        elseif_package = BM.parse_file_julia(elseif_path)
+        @test elseif_package isa BM.BaseModelicaPackage
+        elseif_system = BM.baseModelica_to_ModelingToolkit(elseif_package)
+        @test elseif_system isa System
+        @test parse_basemodelica(elseif_path, parser = :julia) isa System
+    end
+
+    @testset "If-ElseIf-Else Equation (issue #41)" begin
+        ifeq_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "IfElseIfEquation.bmo"
+        )
+        ifeq_package = BM.parse_file_julia(ifeq_path)
+        @test ifeq_package isa BM.BaseModelicaPackage
+        ifeq_system = BM.baseModelica_to_ModelingToolkit(ifeq_package)
+        @test ifeq_system isa System
+        @test parse_basemodelica(ifeq_path, parser = :julia) isa System
+    end
+
+    @testset "No Else If Equation (issue #41)" begin
+        noelse_path = joinpath(
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NoElse.bmo"
+        )
+        noelse_package = BM.parse_file_julia(noelse_path)
+        @test noelse_package isa BM.BaseModelicaPackage
+        noelse_system = BM.baseModelica_to_ModelingToolkit(noelse_package)
+        @test noelse_system isa System
+        @test parse_basemodelica(noelse_path, parser = :julia) isa System
+    end
+
     @testset "Create ODEProblem" begin
         # Test create_odeproblem with Experiment annotation
         experiment_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "Experiment.bmo"
+        )
 
         prob = BM.create_odeproblem(experiment_path, parser = :julia)
         @test prob isa ODEProblem
@@ -91,7 +155,7 @@ PC = BM.ParserCombinator
         @test prob.tspan[2] == 2.0  # StopTime
 
         # Check that reltol and saveat were set from annotation
-        @test prob.kwargs[:reltol] == 1e-06  # Tolerance
+        @test prob.kwargs[:reltol] == 1.0e-6  # Tolerance
         @test prob.kwargs[:saveat] == 0.004  # Interval
 
         # Test parse_experiment_annotation directly
@@ -103,12 +167,13 @@ PC = BM.ParserCombinator
         @test !isnothing(exp_params)
         @test exp_params.StartTime == 0.0
         @test exp_params.StopTime == 2.0
-        @test exp_params.Tolerance == 1e-06
+        @test exp_params.Tolerance == 1.0e-6
         @test exp_params.Interval == 0.004
 
         # Test with model without annotation
         newton_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "NewtonCoolingBase.bmo"
+        )
         prob_no_annotation = BM.create_odeproblem(newton_path, parser = :julia)
         @test prob_no_annotation isa ODEProblem
         # Should use default tspan
@@ -116,9 +181,9 @@ PC = BM.ParserCombinator
         @test prob_no_annotation.tspan[2] == 1.0
 
         # Test that user can override annotation values
-        prob_override = BM.create_odeproblem(experiment_path, parser = :julia, reltol = 1e-8, saveat = 0.01)
+        prob_override = BM.create_odeproblem(experiment_path, parser = :julia, reltol = 1.0e-8, saveat = 0.01)
         @test prob_override isa ODEProblem
-        @test prob_override.kwargs[:reltol] == 1e-8  # User override
+        @test prob_override.kwargs[:reltol] == 1.0e-8  # User override
         @test prob_override.kwargs[:saveat] == 0.01  # User override
         @test prob_override.tspan[2] == 2.0  # Still from annotation
     end
@@ -126,7 +191,8 @@ PC = BM.ParserCombinator
     @testset "Cauer Low Pass Filters" begin
         # Test CauerLowPassAnalog
         cauer_analog_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalog.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalog.bmo"
+        )
         cauer_analog_package = BM.parse_file_julia(cauer_analog_path)
         @test cauer_analog_package isa BM.BaseModelicaPackage
         cauer_analog_system = BM.baseModelica_to_ModelingToolkit(cauer_analog_package)
@@ -136,14 +202,15 @@ PC = BM.ParserCombinator
         # Test that initial conditions (fixed=true) are set correctly
         # MTK v11 replaced defaults with initial_conditions and bindings
         @test !isempty(ModelingToolkit.initial_conditions(cauer_analog_system)) ||
-              !isempty(ModelingToolkit.bindings(cauer_analog_system))
+            !isempty(ModelingToolkit.bindings(cauer_analog_system))
 
         # Test that guess values (fixed=false or no fixed) are set correctly
         @test !isempty(ModelingToolkit.guesses(cauer_analog_system))
 
         # Test CauerLowPassAnalogSine
         cauer_sine_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSine.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSine.bmo"
+        )
         cauer_sine_package = BM.parse_file_julia(cauer_sine_path)
         @test cauer_sine_package isa BM.BaseModelicaPackage
         cauer_sine_system = BM.baseModelica_to_ModelingToolkit(cauer_sine_package)
@@ -152,7 +219,8 @@ PC = BM.ParserCombinator
 
         # Test CauerLowPassAnalogSineNoAssert
         cauer_sine_noassert_path = joinpath(
-            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSineNoAssert.bmo")
+            dirname(dirname(pathof(BM))), "test", "testfiles", "CauerLowPassAnalogSineNoAssert.bmo"
+        )
         cauer_sine_noassert_package = BM.parse_file_julia(cauer_sine_path)
         @test cauer_sine_noassert_package isa BM.BaseModelicaPackage
         cauer_sine_noassert_system = BM.baseModelica_to_ModelingToolkit(cauer_sine_noassert_package)

--- a/test/testfiles/IfElseIfEquation.bmo
+++ b/test/testfiles/IfElseIfEquation.bmo
@@ -1,0 +1,16 @@
+//! base 0.1.0
+package 'IfElseIfEquation'
+  model 'IfElseIfEquation'
+    Real 'x';
+    Real 'y';
+  equation
+    if time < 0.33 then
+      'x' = 1.0;
+    elseif time < 0.66 then
+      'x' = 2.0;
+    else
+      'x' = 3.0;
+    end if;
+    der('y') = 'x';
+  end 'IfElseIfEquation';
+end 'IfElseIfEquation';

--- a/test/testfiles/InlineIf.bmo
+++ b/test/testfiles/InlineIf.bmo
@@ -1,0 +1,10 @@
+//! base 0.1.0
+package 'InlineIf'
+  model 'InlineIf'
+    Real 'x';
+    Real 'y';
+  equation
+    'x' = if time < 0.5 then 1.0 else 2.0;
+    der('y') = 'x';
+  end 'InlineIf';
+end 'InlineIf';

--- a/test/testfiles/InlineIfElseIf.bmo
+++ b/test/testfiles/InlineIfElseIf.bmo
@@ -1,0 +1,10 @@
+//! base 0.1.0
+package 'InlineIfElseIf'
+  model 'InlineIfElseIf'
+    Real 'x';
+    Real 'y';
+  equation
+    'x' = if time < 0.33 then 1.0 elseif time < 0.66 then 2.0 else 3.0;
+    der('y') = 'x';
+  end 'InlineIfElseIf';
+end 'InlineIfElseIf';

--- a/test/testfiles/InlineIfNested.bmo
+++ b/test/testfiles/InlineIfNested.bmo
@@ -1,0 +1,10 @@
+//! base 0.1.0
+package 'InlineIfNested'
+  model 'InlineIfNested'
+    Real 'x';
+    Real 'y';
+  equation
+    'x' = if time < 0.33 then 1.0 else if time < 0.66 then 2.0 else 3.0;
+    der('y') = 'x';
+  end 'InlineIfNested';
+end 'InlineIfNested';

--- a/test/testfiles/NoElse.bmo
+++ b/test/testfiles/NoElse.bmo
@@ -1,0 +1,16 @@
+//! base 0.1.0
+package 'NoElse'
+  model 'NoElse'
+    Real 'x';
+    Real 'y';
+  equation
+    if time < 0.33 then
+      'x' = 1.0;
+    elseif time < 0.66 then
+      'x' = 2.0;
+    elseif true then
+      'x' = 3.0;
+    end if;
+    der('y') = 'x';
+  end 'NoElse';
+end 'NoElse';


### PR DESCRIPTION
## Summary

- Adds support for inline if-expressions (`if cond then val1 else val2`) in equations, parsed into `ifelse()` calls (fixes #39)
- Adds support for block-level if-equations with `if/elseif/else/end if` syntax, parsed into nested `ifelse()` calls per variable (fixes #41)
- Fixes a pre-existing parser hang in the Julia ParserCombinator parser when parsing 3+ branch if-equations by adding keyword lookahead guards to prevent exponential backtracking with `NoCache`
- Both Julia (ParserCombinator) and ANTLR parsers are tested

## Changes

**Julia parser (`src/julia_parser.jl`):**
- Swap `expression_no_decoration` order so `if_expression` is tried before `simple_expression`
- Use `expression` (Delayed) for if-expression else-value to support nested if-expressions
- Rewrite `BaseModelicaIfEquation` constructor as a state machine that correctly collects per-branch equation lists
- Add `guarded_eq` matcher with keyword negative lookahead to prevent exponential backtracking in nested `Star()` patterns

**Evaluator (`src/evaluator.jl`):**
- Rewrite `eval_AST(BaseModelicaIfEquation)` to handle list-of-lists `thens` structure with proper else/no-else detection
- Build nested `ifelse()` for each unique LHS variable across all branches

**Test files added:**
- `InlineIf.bmo` - Basic inline if-expression
- `InlineIfNested.bmo` - Nested inline if-expressions
- `InlineIfElseIf.bmo` - Inline if-elseif-else expression
- `IfElseIfEquation.bmo` - Block if-elseif-else equation
- `NoElse.bmo` - Block if-elseif-elseif equation (no else, using `elseif true`)

## Test plan

- [x] All 18 test files pass with Julia parser
- [x] All 18 test files pass with ANTLR parser
- [x] `Pkg.test()` passes: Quality Assurance 11/11, BaseModelica 195/195
- [x] Runic.jl formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)