### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,22 @@
+authors = ["jClugstor <jadonclugston@gmail.com> and contributors"]
 name = "BaseModelica"
 uuid = "a17d5099-185d-4ff5-b5d3-51aa4569e56d"
 version = "1.8.0"
-authors = ["jClugstor <jadonclugston@gmail.com> and contributors"]
+
+[compat]
+Aqua = "0.8"
+CondaPkg = "0.2.33"
+DiffEqBase = "7.5"
+MLStyle = "0.4.17"
+ModelingToolkit = "11.24.0"
+ModelingToolkitBase = "1.34.0"
+OrdinaryDiffEq = "7"
+ParserCombinator = "2"
+Pkg = "1"
+PythonCall = "0.9.29"
+SafeTestsets = "0.1"
+Test = "1.10"
+julia = "1.10"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
@@ -11,21 +26,6 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
 ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
-
-[compat]
-Aqua = "0.8"
-CondaPkg = "0.2.33"
-DiffEqBase = "6.211.0, 7.5"
-MLStyle = "0.4.17"
-ModelingToolkit = "11"
-ModelingToolkitBase = "1.16.2"
-OrdinaryDiffEq = "6.103, 7"
-ParserCombinator = "2"
-Pkg = "1"
-PythonCall = "0.9.29"
-SafeTestsets = "0.1"
-Test = "1.10"
-julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `authors = ["jClugstor <jadonclugston@gmail.com> and contributors"];DiffEqBase = "7.5";ModelingToolkit = "11.24.0";ModelingToolkitBase = "1.34.0";OrdinaryDiffEq = "7";CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab";DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e";MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078";ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78";ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839";ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46";PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d";`authors = ["jClugstor <jadonclugston@gmail.com> and contributors"];DiffEqBase = "7.5";ModelingToolkit = "11.24.0";ModelingToolkitBase = "1.34.0";OrdinaryDiffEq = "7";CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab";DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e";MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078";ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78";ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839";ParserCombinator = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46";PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)