### PR TITLE
Migrate Downgrade.yml to SciML/.github central caller

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,26 +11,16 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  downgrade:
+    name: Downgrade
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "1.10"
+      allow-reresolve: false
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

Migrates the bespoke `Downgrade.yml` (raw `julia-actions/julia-downgrade-compat@v2` job) to the centralized reusable caller `SciML/.github/.github/workflows/downgrade.yml@v1`, matching the pattern already used by `Tests.yml` in this repo and by ~119 other SciML repos.

### What changed
- `uses: SciML/.github/.github/workflows/downgrade.yml@v1` with `secrets: inherit`.
- `group: Core` preserved (sole matrix entry).
- `julia-version: "1.10"` preserved (LTS; Julia 1.10 support stays required).
- `allow-reresolve: false` — strict, matches the prior `ALLOW_RERESOLVE: false`.
- `mode` defaults to `deps`. The prior workflow declared a `downgrade_mode: ['alldeps']` matrix variable but **never referenced it** in the `julia-downgrade-compat@v2` step (the step only set `skip: Pkg,TOML`), so its effective mode was already `deps`. The central caller's default `deps` reproduces that exactly.
- `skip` defaults to `Pkg,TOML` (matches prior).
- `pull_request`/`push` triggers on `main` with `paths-ignore: docs/**` preserved.

### Local verification (Julia 1.10, isolated depot)
Reproduced CI's strict downgrade exactly: pinned only the direct `[deps]` `[compat]` entries to their floors (CondaPkg=0.2.33, DiffEqBase=7.5, MLStyle=0.4.17, ModelingToolkit=11.24.0, ModelingToolkitBase=1.34.0, ParserCombinator=2, PythonCall=0.9.29), left `[extras]` test deps unpinned, then ran `Pkg.test(; allow_reresolve=false)` with `GROUP=Core`.

```
Test Summary: | Pass  Total     Time
BaseModelica  |  238    238  2m57.5s
     Testing BaseModelica tests passed
```

Resolution succeeded and **238/238 tests passed at the existing floors** — no `[compat]` floor bumps were required, so this PR touches only `Downgrade.yml`.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)