### PR TITLE
style: apply Runic v1.7.0 formatting

### DIFF
--- a/mwe.jl
+++ b/mwe.jl
@@ -9,16 +9,20 @@ diode_path = joinpath(dirname(pathof(BM)), "..", "test", "testfiles", "Character
 diode_package = BM.parse_file_antlr(diode_path)
 diode_system = BM.baseModelica_to_ModelingToolkit(diode_package)
 
-prob = ODEProblem(diode_system, [], (0.0, 1.0);
-    missing_guess_value = ModelingToolkitBase.MissingGuessValue.Constant(0.0))
+prob = ODEProblem(
+    diode_system, [], (0.0, 1.0);
+    missing_guess_value = ModelingToolkitBase.MissingGuessValue.Constant(0.0)
+)
 
 sol = solve(prob)
 
 println("Retcode: ", sol.retcode)
 
-plot(sol, idxs = [
-    diode_system.var"Ideal.v",
-    diode_system.var"With_Ron_Goff.v",
-    diode_system.var"With_Ron_Goff_Vknee.v",
-], label = ["Ideal v" "With_Ron_Goff v" "With_Ron_Goff_Vknee v"],
-    title = "Diode Voltages", xlabel = "time (s)", ylabel = "V")
+plot(
+    sol, idxs = [
+        diode_system.var"Ideal.v",
+        diode_system.var"With_Ron_Goff.v",
+        diode_system.var"With_Ron_Goff_Vknee.v",
+    ], label = ["Ideal v" "With_Ron_Goff v" "With_Ron_Goff_Vknee v"],
+    title = "Diode Voltages", xlabel = "time (s)", ylabel = "V"
+)

--- a/src/ast.jl
+++ b/src/ast.jl
@@ -3,11 +3,11 @@
 # Values are ordered by increasing preference for state selection:
 #   never < avoid < default < prefer < always
 @enum StateSelectValue begin
-    StateSelectNever   = -100
-    StateSelectAvoid   = -10
+    StateSelectNever = -100
+    StateSelectAvoid = -10
     StateSelectDefault = 0
-    StateSelectPrefer  = 10
-    StateSelectAlways  = 100
+    StateSelectPrefer = 10
+    StateSelectAlways = 100
 end
 
 @data BaseModelicaASTNode begin

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -439,8 +439,8 @@ end
 
 function extract_time_threshold(cond_ast)
     is_time_ref(x) = x isa BaseModelicaComponentReference &&
-                     length(x.ref_list) == 1 &&
-                     x.ref_list[1].name == "time"
+        length(x.ref_list) == 1 &&
+        x.ref_list[1].name == "time"
     if (cond_ast isa BaseModelicaLessThan || cond_ast isa BaseModelicaLEQ) &&
             is_time_ref(cond_ast.left) && cond_ast.right isa BaseModelicaNumber
         return Float64(cond_ast.right.val)
@@ -518,7 +518,8 @@ function eval_AST(model::BaseModelicaModel)
                 disc_sym = only(@discretes($name(t)::Bool))
                 # Apply start value if declared (sets the initial discrete state)
                 start_val = get_class_modification_value(
-                    comp.component_list[1].declaration.modification, "start")
+                    comp.component_list[1].declaration.modification, "start"
+                )
                 default_val = !isnothing(start_val) ? start_val : false
                 disc_sym = ModelingToolkit.setdefault(disc_sym, default_val)
                 variable_map[name] = disc_sym
@@ -640,8 +641,8 @@ function eval_AST(model::BaseModelicaModel)
     # variable_map is now fully resolved (after Pass 3.5), so symbol keys are stable.
     state_priorities = Dict(
         variable_map[name] => val
-        for (name, val) in state_select_raw
-        if haskey(variable_map, name) && val != Int(StateSelectDefault)
+            for (name, val) in state_select_raw
+            if haskey(variable_map, name) && val != Int(StateSelectDefault)
     )
 
     # Split equations into when-equations (→ continuous callbacks) and regular equations.
@@ -758,10 +759,12 @@ function eval_AST(model::BaseModelicaModel)
                 # which has a bug with discrete parameter names containing subscripts.
                 affect = ModelingToolkitBase.ImperativeAffect(
                     (m, o, ctx, integ) -> (; off = true);
-                    modified = (; off = off_sym))
+                    modified = (; off = off_sym)
+                )
                 affect_neg = ModelingToolkitBase.ImperativeAffect(
                     (m, o, ctx, integ) -> (; off = false);
-                    modified = (; off = off_sym))
+                    modified = (; off = off_sym)
+                )
                 cb = ModelingToolkit.SymbolicContinuousCallback(
                     [crossing ~ 0],
                     affect;
@@ -805,7 +808,7 @@ function eval_AST(model::BaseModelicaModel)
 
     # Split when-callbacks by type: sample()/periodic → discrete, zero-crossing → continuous.
     when_continuous = filter(cb -> cb isa ModelingToolkit.SymbolicContinuousCallback, when_callbacks)
-    when_discrete   = filter(cb -> cb isa ModelingToolkit.SymbolicDiscreteCallback,   when_callbacks)
+    when_discrete = filter(cb -> cb isa ModelingToolkit.SymbolicDiscreteCallback, when_callbacks)
     all_continuous_events = vcat(when_continuous, bool_crossing_callbacks)
     @named sys = System(
         real_eqs, t, vars, all_pars;
@@ -822,11 +825,11 @@ function eval_AST(package::BaseModelicaPackage)
     empty!(enum_map)
     # Register built-in StateSelect enumeration so StateSelect.prefer etc. resolve correctly.
     enum_map["StateSelect"] = Dict(
-        :never   => Int(StateSelectNever),
-        :avoid   => Int(StateSelectAvoid),
+        :never => Int(StateSelectNever),
+        :avoid => Int(StateSelectAvoid),
         :default => Int(StateSelectDefault),
-        :prefer  => Int(StateSelectPrefer),
-        :always  => Int(StateSelectAlways),
+        :prefer => Int(StateSelectPrefer),
+        :always => Int(StateSelectAlways),
     )
     for class_def in package.class_defs
         if class_def isa BaseModelicaClassDefinition && class_def.class isa BaseModelicaEnumeration

--- a/test/test_antlr_parser.jl
+++ b/test/test_antlr_parser.jl
@@ -394,8 +394,10 @@ BM = BaseModelica
         diode_system = BM.baseModelica_to_ModelingToolkit(diode_package)
         @test diode_system isa System
 
-        prob = ODEProblem(diode_system, [], (0.0, 1.0);
-            missing_guess_value = ModelingToolkitBase.MissingGuessValue.Constant(0.0))
+        prob = ODEProblem(
+            diode_system, [], (0.0, 1.0);
+            missing_guess_value = ModelingToolkitBase.MissingGuessValue.Constant(0.0)
+        )
         sol = solve(prob)
         @test sol.retcode == ReturnCode.Success
     end


### PR DESCRIPTION
## Summary

The Runic Format Check CI (`fredrikekre/runic-action@v1`, Runic v1.7.0) is currently failing on `main` because the tree is not conformant to Runic v1.7.0.

This PR applies Runic v1.7.0 formatting over the whole repository to make the check pass. It is **pure formatting** — no logic, identifier, or value changes. 4 files were reformatted:

- `mwe.jl`
- `src/ast.jl`
- `src/evaluator.jl`
- `test/test_antlr_parser.jl`

Changes are limited to whitespace alignment, function-call argument bracket layout, and indentation. After applying, a Runic v1.7.0 `--check` pass over all 16 `.jl` files reports zero remaining diffs.

This is a separate, self-contained formatting PR so it can be reviewed and merged independently of any other work. No CI/Project.toml/non-`.jl` files were touched.

---

**Note: please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)