### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -21,5 +21,5 @@ jobs:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       group: "${{ matrix.group }}"
-      julia-version: "1.10"
+      julia-version: "lts"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,16 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-        
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot` workflow (permissions block + steps) with the canonical `SciML/.github` `tagbot.yml@v1` thin caller. This repo is a single package (no `lib/` subpackages), so the single-package caller form is used.
- **Downgrade caller**: changed `julia-version: "1.10"` to the `lts` alias (no `skip` input was present).
- No monorepo subpackage matrix needed (no registered `lib/<Name>` subpackages).
- `.typos.toml` step skipped (already present at repo root).
- `[compat] julia` floors were not touched.

Ignore until reviewed by @ChrisRackauckas.