### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,19 +20,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - Core
-          - NoPre
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[NoPre]
+versions = ["lts", "1", "pre"]


### PR DESCRIPTION
## Summary

Converts the root test workflow `.github/workflows/Tests.yml` to the canonical thin caller `SciML/.github/.github/workflows/grouped-tests.yml@v1`, declaring the group × version matrix once in a ROOT `test/test_groups.toml`.

The package already dispatches `Core` / `NoPre` groups via the `GROUP` env var in `test/runtests.jl` (Category A), so **no `runtests.jl` change** was made. `NoPre` runs the QA (Aqua) + JET checks, guarded by `isempty(VERSION.prerelease)` in runtests.jl.

### Changes
- `.github/workflows/Tests.yml`: matrix test job replaced by the thin caller. Filename and `name: "Tests"` are unchanged so branch-protection status checks are preserved. `on:` triggers (pull_request / push / schedule, `paths-ignore: docs/**`) and `concurrency:` are preserved verbatim.
- `test/test_groups.toml` (new, repo root): declares the matrix.

```toml
[Core]
versions = ["lts", "1", "pre"]

[NoPre]
versions = ["lts", "1", "pre"]
```

No `with:` inputs were needed: the old caller used `tests.yml@v1` defaults throughout (GROUP env var, `check-bounds: yes`, coverage on, `coverage-directories: src,ext`), all of which are the defaults of `grouped-tests.yml@v1`.

### Matrix match — 6/6 exact

`compute_affected_sublibraries.jl --root-matrix` (from `SciML/.github@v1`) emits exactly the previous workflow's cross product:

| group | versions |
|-------|----------|
| Core  | lts, 1, pre |
| NoPre | lts, 1, pre |

Old workflow: `group ∈ {Core, NoPre} × version ∈ {1, lts, pre}` = 6 cells. Emitted: the same 6 (group, version) pairs, all `runner: ubuntu-latest` (Linux-only; no `os` field added). Group names are passed verbatim to `GROUP`, preserving the existing runtests.jl dispatch.

### QA
Category A: existing QA (Aqua + JET) already wired via the `NoPre` group; static matrix-verify only, no local QA run. TOML and YAML both parse cleanly.

Ignore until reviewed by @ChrisRackauckas.