### PR TITLE
Route QA group through the reserved qa= keyword in run_tests

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,1 +1,3 @@
 [default.extend-words]
+# Nd is the Modelica LimPID derivative-gain parameter name in the PID_Controller test fixture
+Nd = "Nd"

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -376,9 +376,14 @@ function eval_AST(when_eq::BaseModelicaWhenEquation)
             # Only fire on positive zero-crossing (condition becomes true) → Modelica edge semantics
             condition_sym = eval_when_rhs(condition_ast; in_body = false)
             crossing = to_zero_crossing(condition_sym)
+            # A when-condition is scalar, so `crossing ~ 0` is a single Equation.
+            # Annotate the literal as Equation[...] so it is always Vector{Equation}:
+            # without it inference admits a spurious Vector{Vector{Equation}} arm
+            # (crossing is a Union including a vector case) for which
+            # SymbolicContinuousCallback has no matching method.
             push!(
                 callbacks, ModelingToolkit.SymbolicContinuousCallback(
-                    [crossing ~ 0], affects;
+                    Equation[crossing ~ 0], affects;
                     affect_neg = nothing,
                     discrete_parameters = discrete_params_for_cb
                 )
@@ -766,7 +771,7 @@ function eval_AST(model::BaseModelicaModel)
                     modified = (; off = off_sym)
                 )
                 cb = ModelingToolkit.SymbolicContinuousCallback(
-                    [crossing ~ 0],
+                    Equation[crossing ~ 0],
                     affect;
                     affect_neg = affect_neg,
                     reinitializealg = BrownFullBasicInit(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ run_tests(;
         @safetestset "ANTLR Parser Tests" include("test_antlr_parser.jl")
         return @safetestset "Error Message Tests" include("test_error_messages.jl")
     end,
-    groups = Dict("QA" => qa_group),
+    qa = qa_group,
     umbrellas = Dict("Quality" => ["QA"]),
     # Original runtests ran QA/Quality only for those explicit GROUPs, never under
     # "All"; curate "All" to Core only to preserve that.


### PR DESCRIPTION
## Problem

The QA matrix entry of `tests` CI on `main` fails for both `julia 1` and `julia lts`:

```
ERROR: LoadError: ArgumentError: run_tests: GROUP="QA" was requested but no `qa` body was provided
   @ SciMLTesting ~/.julia/packages/SciMLTesting/.../src/SciMLTesting.jl:959
   @ ~/_work/BaseModelica.jl/BaseModelica.jl/test/runtests.jl:20
```

This was introduced by #134, which rewrote `test/runtests.jl` to the SciMLTesting v1.2 explicit-args `run_tests` form but registered the QA group via `groups = Dict("QA" => qa_group)`.

In the explicit-args dispatcher, `"QA"` (like `"Core"`/`"All"`) is a **reserved** group name: when `GROUP=QA` is requested it is resolved against the `qa=` keyword and is **not** looked up in the `groups` Dict. With `qa` left unset (default `nothing`), the reserved-name branch throws.

## Fix

Pass the existing `qa_group` thunk through the reserved `qa=` keyword instead of `groups`:

```diff
-    groups = Dict("QA" => qa_group),
+    qa = qa_group,
```

`GROUP=QA` and the `"Quality"` umbrella alias both resolve to `qa_group`; `GROUP=Core` and the curated `GROUP=All` (`all = ["Core"]`) are unchanged. The prerelease no-op guard inside `qa_group` is preserved.

## Local verification

Against the registered `SciMLTesting` v1.2.0 (the build CI resolved) on Julia 1.10, with a stub thunk to exercise the dispatcher:

```
=== BROKEN form (current main), GROUP=QA ===
THREW: ArgumentError: run_tests: GROUP="QA" was requested but no `qa` body was provided

=== FIXED form ===
GROUP=Core     => ["CORE"]
GROUP=QA       => ["QA"]
GROUP=Quality  => ["QA"]
GROUP=All      => ["CORE"]
```

The broken form reproduces the CI error verbatim; the fixed form routes every GROUP correctly. `Runic` (v1.7) reports `test/runtests.jl` is already formatted.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: fix the genuine JET report exposed once the QA group runs (Julia 1.12)

With the QA routing fixed above, the QA matrix entry on the `julia 1` channel
(now 1.12) actually runs `test/qa/test_jet.jl`, which exposed a single genuine
`report_package` MethodError in BaseModelica's own source at
`src/evaluator.jl` (`eval_AST(::BaseModelicaWhenEquation)`):

```
no matching method found `kwcall(::@NamedTuple{affect_neg::Nothing,
  discrete_parameters::Vector{Any}}, ::Type{SymbolicContinuousCallback},
  ::Vector{Vector{Equation}}, ::Vector{Equation})` (1/2 union split)
```

Root cause: `to_zero_crossing`/`eval_when_rhs` return a `Union` whose vector arm
makes `crossing ~ 0` inferred as `Union{Equation, Vector{Equation}}`, so the
array literal `[crossing ~ 0]` is `Union{Vector{Equation}, Vector{Vector{Equation}}}`.
The `Vector{Vector{Equation}}` arm has no matching `SymbolicContinuousCallback`
method — a real method error on that inferred path. `lts`/1.10 didn't exercise
that arm, so it only surfaced on 1.12.

Fix: annotate both `SymbolicContinuousCallback` zero-crossing literals as
`Equation[crossing ~ 0]` so they are unambiguously `Vector{Equation}`. A
when-condition is always scalar, so this is behavior-preserving for valid input
and removes the spurious method path.

Local verification on Julia 1.12.6 against the registered `test/qa` env: JET
`report_package` over all 364 top-level definitions now reports **0 errors**
("No errors detected"), so `test/qa/test_jet.jl:12` passes. Runic v1.7 reports
`src/evaluator.jl` already formatted.

Please ignore until reviewed by @ChrisRackauckas.
