### PR TITLE
Release prep: bump BaseModelica to 1.9.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["jClugstor <jadonclugston@gmail.com> and contributors"]
 name = "BaseModelica"
 uuid = "a17d5099-185d-4ff5-b5d3-51aa4569e56d"
-version = "1.9.0"
+version = "1.9.1"
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
Patch release for the accumulated docstring, QA, and test-scaffolding changes since 1.9.0; no functional or API changes.