### PR TITLE
Verify rendered public API docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ create_odeproblem
 ## Contributing
 
   - Please refer to the
-    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
+    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://sciml.github.io/ColPrac/stable/)
     for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,8 +3,6 @@ using JET
 
 run_qa(
     BaseModelica;
-    explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     # MLStyle's @match expands to ambiguous-looking method tables; the original QA
     # ran ambiguities non-recursively, so keep that.
     #

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,6 +4,7 @@ using JET
 run_qa(
     BaseModelica;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     # MLStyle's @match expands to ambiguous-looking method tables; the original QA
     # ran ambiguities non-recursively, so keep that.
     #


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs coverage for BaseModelica
- update the ColPrac docs link to the hosted docs URL so Documenter linkcheck does not fail on a GitHub HTML 429

## Audit
BaseModelica currently exports three package-owned public APIs: `parse_basemodelica`, `parse_experiment_annotation`, and `create_odeproblem`. All three already have source docstrings and are rendered in `docs/src/index.md` via the API `@docs` block.

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`
  - `Quality Assurance | 16 pass, 1 broken, 17 total`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`
  - passed; pre-existing Documenter warning remains for non-rendered internal docstrings
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no -e 'using Pkg; Pkg.activate(mktempdir()); Pkg.add(Pkg.PackageSpec(name="Runic", version="1")); using Runic; exit(Runic.main(["--check", "."]))'`
  - passed with Runic v1.7.0
- clean detached worktree at this commit: `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`
  - `Julia Parser Tests | 75 pass`
  - `ANTLR Parser Tests | 138 pass`
  - `Error Message Tests | 25 pass`
  - `Testing BaseModelica tests passed`
