### PR TITLE
Fix Downgrade Core hang by raising the Symbolics floor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["jClugstor <jadonclugston@gmail.com> and contributors"]
 name = "BaseModelica"
 uuid = "a17d5099-185d-4ff5-b5d3-51aa4569e56d"
-version = "1.9.2"
+version = "1.9.3"
 
 [compat]
 Aqua = "0.8"
@@ -17,7 +17,7 @@ PythonCall = "0.9.29"
 SciMLBase = "2, 3"
 SymbolicIndexingInterface = "0.3"
 SymbolicUtils = "3, 4"
-Symbolics = "5, 6, 7"
+Symbolics = "7.35"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 Test = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Fixes #148.

## What is actually wrong

`Downgrade (Core)` has been hitting the six-hour execution cap since #146. The failure has nothing to do with ANTLR, PythonCall, or any source change in #146 — the `@info "ANTLR parser initialized successfully"` line is simply the last thing flushed to stderr before a `@safetestset` that prints nothing until it finishes, so it looked like the hang was at initialization.

Interrupting a reproduced hang gives the real location:

```
[35] macro expansion @ test/test_antlr_parser.jl:401 [inlined]
[37] macro expansion @ test/test_antlr_parser.jl:388 [inlined]
[33] solve(::ODEProblem{...}) @ DiffEqBase .../solve.jl:591
```

That is `sol = solve(prob)` in the **`Characteristic Ideal Diodes`** testset — a 3-unknown system with 3 continuous events. 125 of the 126 ANTLR assertions pass before it. Driving the same model through the `:julia` parser hangs identically, so the parser is not involved.

The mechanism, from the `SIGTERM` backtrace after one hour:

```
Allocations: 11355326474 ; GC: 120305
...
ldiv! (QR)                       LinearAlgebra
_reuse_qr_fallback                LinearSolve/src/default.jl:706
dolinsolve                        OrdinaryDiffEqDifferentiation
perform_step!                     OrdinaryDiffEqRosenbrock/rosenbrock_perform_step.jl:642
solve!                            OrdinaryDiffEqCore/src/solve.jl:772
```

Every Rosenbrock step falls through to LinearSolve's **QR fallback**, the path taken when the `W` matrix is singular. This is not a slow solve, it is a non-converging one — `maxiters` never trips because the loop is not accumulating accepted steps.

## Why #146 triggered it

#146 added `SciMLBase`, `SymbolicIndexingInterface`, `SymbolicUtils` and `Symbolics` as **direct** dependencies. Downgrade only pins direct dependencies, so those four went from "resolved to newest compatible" to "pinned at their declared floor". Reconstructing both manifests with `julia-actions/julia-downgrade-compat` at `2c401f8` (mode `deps`, Julia 1.10) — the bad one matches the versions reported in the issue exactly — the graph moved a long way:

| package | green `6bf0435` | bad `4c85f39` |
|---|---|---|
| SciMLBase | 3.39.1 | 3.1.0 |
| Symbolics | 7.35.0 | **7.18.1** |
| SymbolicUtils | 4.44.0 | 4.23.1 |
| SymbolicIndexingInterface | 0.3.51 | 0.3.43 |
| LinearSolve | 5.4.0 | 3.87.0 |
| OrdinaryDiffEqCore | 4.8.0 | 4.3.0 |
| NonlinearSolveBase | 2.39.1 | 2.30.3 |

(plus ~20 more). The earlier analysis in the issue compared only packages pinned in *both* runs, which is precisely the set guaranteed not to differ.

## Which floor is responsible

One floor raised at a time, everything else left alone, re-resolved with the real action each time:

| candidate | diode solve |
|---|---|
| control (unmodified) | hangs |
| `SciMLBase = "3.39.1"` | **hangs** |
| `SymbolicIndexingInterface = "0.3.51"` | **hangs** |
| `SymbolicUtils = "4.44"` | **hangs** |
| `Symbolics = "7.35"` | **Success, 27.1s, 86 steps** |

The `SciMLBase` candidate is the decisive one: it ran with the entire modern solver stack (`SciMLBase` 3.39.1, `OrdinaryDiffEqCore` 4.8.0, `LinearSolve` 5.4.0) and still hung with `Symbolics` held at 7.18.1. The solver stack is exonerated — old `Symbolics` generates the singular system.

Narrowing the floor: **7.20 hangs, 7.25 solves** (24.4s), so the true minimum is in `(7.20, 7.25]`. This PR ships `7.35` because that is the value verified end-to-end against the full suite; a full `GROUP=Core` run at `7.25` is in progress and I will lower the floor to it if it is green.

## Local verification

Full `GROUP=Core` on the downgraded manifest with this change, Julia 1.10 (lts):

```
### resolved
  SciMLBase                     3.1.0
  OrdinaryDiffEqCore            4.3.0
  SymbolicIndexingInterface     0.3.43
  SymbolicUtils                 4.37.0
  Symbolics                     7.35.0
  LinearSolve                   3.87.0
### GROUP=Core Pkg.test
Julia Parser Tests  |  75   75  1m19.8s
ANTLR Parser Tests  | 138  138    48.9s
Error Message Tests |  25   25    47.0s
     Testing BaseModelica tests passed
### test rc=0
```

Note `SciMLBase` 3.1.0, `OrdinaryDiffEqCore` 4.3.0 and `LinearSolve` 3.87.0 are still at their old floors in that green run — further confirmation that only the `Symbolics` floor mattered.

## Left deliberately untouched

`SciMLBase = "2, 3"`, `SymbolicUtils = "3, 4"` and `SymbolicIndexingInterface = "0.3"` are almost certainly also wrong — the package requires ModelingToolkit 11.24 / ModelingToolkitBase 1.34, which cannot work with SciMLBase 2 or SymbolicUtils 3. They are not what breaks downgrade today, so tightening them belongs in a separate PR rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3YyP3QreXNR2LCjP8RA31
