### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["jClugstor <jadonclugston@gmail.com> and contributors"]
 name = "BaseModelica"
 uuid = "a17d5099-185d-4ff5-b5d3-51aa4569e56d"
-version = "1.9.3"
+version = "1.10.0"
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `main` can be registered in the General registry.

- BaseModelica: 1.9.3 -> 1.10.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
