### PR TITLE
Remove x86 CI lane (PythonCall/micromamba unavailable on i686)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,11 +1,6 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- After Symbolics 7.39.2, Core x86 still fails at `SciMLBasePythonCallExt` init: \`neither pixi nor micromamba is automatically available\` (CondaPkg/PythonCall has no usable i686 micromamba product).
- Same class of platform gap as SciML/SciPyDiffEq.jl#79 — not a BaseModelica logic bug.
- Drop the hard-fail x86 lane so CI fails only on real portable regressions.

## Test plan
- [ ] Remaining Core/QA lanes green


Made with [Cursor](https://cursor.com)